### PR TITLE
Add transcription vocabulary corrections (Grey NATO, Hodinkee, brands)

### DIFF
--- a/app/tasks/markdown.py
+++ b/app/tasks/markdown.py
@@ -6,6 +6,7 @@ from prefect import task
 from utils.logging import get_logger
 
 from constants import SPEAKER_MAPFILE
+from text_corrections import normalize_transcript_text
 
 
 @task(
@@ -48,7 +49,7 @@ def generate_episode_markdown(
     # Load speaker map and synopsis
     speaker_map = defaultdict(lambda: "Unknown")
     speaker_map.update(json.loads(speaker_map_path.read_text()))
-    synopsis = synopsis_path.read_text()
+    synopsis = normalize_transcript_text(synopsis_path.read_text())
 
     # Load chunked transcript
     whisper_output_path = episode_dir / "whisper-output.json"
@@ -59,7 +60,7 @@ def generate_episode_markdown(
     attributed_chunks = []
     for start_time, speaker_id, text in chunks:
         speaker_name = speaker_map[speaker_id]
-        attributed_chunks.append((start_time, speaker_name, text))
+        attributed_chunks.append((start_time, speaker_name, normalize_transcript_text(text)))
 
     # Generate markdown header
     title = episode_data.get('title', 'Unknown Episode')

--- a/app/test_text_corrections.py
+++ b/app/test_text_corrections.py
@@ -1,0 +1,77 @@
+"""Tests for transcription vocabulary corrections."""
+import pytest
+
+from text_corrections import normalize_transcript_text
+
+
+@pytest.mark.parametrize("raw,expected", [
+    # Grey NATO — "nado" family, various casings/spacings
+    ("welcome to another episode of The Graynado", "welcome to another episode of The Grey NATO"),
+    ("The Grey Nado is a podcast", "The Grey NATO is a podcast"),
+    ("greynado", "Grey NATO"),
+    ("gray nado", "Grey NATO"),
+    ("GreyNado", "Grey NATO"),
+    ("the gray-nado show", "the Grey NATO show"),
+    ("Graynado's crew", "Grey NATO's crew"),
+])
+def test_grey_nato_nado_family(raw, expected):
+    assert normalize_transcript_text(raw) == expected
+
+
+@pytest.mark.parametrize("text", [
+    # "nato" spelled forms and URLs must be left alone (URL-safe / strap-safe)
+    "please visit thegreynato.com for details",
+    "https://thegreynato.substack.com/p/episode",
+    "I put it on a gray NATO strap",
+    "The Grey NATO",
+])
+def test_grey_nato_leaves_urls_and_straps_untouched(text):
+    assert normalize_transcript_text(text) == text
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("I read it on Hodinky", "I read it on Hodinkee"),
+    ("over at Hodinki radio", "over at Hodinkee radio"),
+    ("the Hodinke shop", "the Hodinkee shop"),
+    ("Hodinkey", "Hodinkee"),
+    ("Hodinkie", "Hodinkee"),
+    ("works at Hoding", "works at Hodinkee"),
+    ("Hodingki", "Hodinkee"),
+])
+def test_hodinkee_misspellings(raw, expected):
+    assert normalize_transcript_text(raw) == expected
+
+
+@pytest.mark.parametrize("text", [
+    # correct spelling and its real domain must not be altered
+    "Hodinkee published a review",
+    "see hodinkee.com/shop for more",
+])
+def test_hodinkee_correct_form_untouched(text):
+    assert normalize_transcript_text(text) == text
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("the Blompa Fifty Fathoms", "the Blancpain Fifty Fathoms"),
+    ("a Blancpan diver", "a Blancpain diver"),
+    ("two Blancpans", "two Blancpains"),
+    ("the Aqua star Deepstar", "the Aquastar Deepstar"),
+    ("my Pelegos 39", "my Pelagos 39"),
+    ("a Vasheron Constantin", "a Vacheron Constantin"),
+    ("the Odemar Piguet", "the Audemars Piguet"),
+    ("a Tuder Black Bay", "a Tudor Black Bay"),
+    ("the Omega Speed master", "the Omega Speedmaster"),
+    ("a Longine watch", "a Longines watch"),
+])
+def test_watch_brand_corrections(raw, expected):
+    assert normalize_transcript_text(raw) == expected
+
+
+def test_correct_brand_names_untouched():
+    text = "the Blancpain, Aquastar, Pelagos, Tudor and Longines are all correct"
+    assert normalize_transcript_text(text) == text
+
+
+def test_empty_and_none_safe():
+    assert normalize_transcript_text("") == ""
+    assert normalize_transcript_text(None) is None

--- a/app/text_corrections.py
+++ b/app/text_corrections.py
@@ -1,0 +1,60 @@
+"""
+Transcription vocabulary corrections.
+
+Fluid Audio (STT) consistently mis-transcribes some show-specific vocabulary —
+most notably the show name "The Grey NATO" (rendered as "Graynado", "Grey Nado",
+etc.) and "Hodinkee" ("Hodinky", "Hodinki", ...), plus a handful of watch brands.
+
+`normalize_transcript_text()` applies a curated set of regex substitutions to
+transcript text at markdown-generation time. The raw STT output in
+`whisper-output.json` is left untouched (it remains the authentic source); only
+the displayed/searched transcript is corrected.
+
+Design rules for every correction:
+- URL-SAFE: only match tokens that never appear in a real URL. The show's real
+  domains spell it "greynato"/"thegreynato.com" (with "nato"), so we correct only
+  the "nado" family and never touch the "nato" spelled forms. Hodinkee's real
+  domain is "hodinkee.com"; we correct only the mis-spelled forms, never
+  "hodinkee" itself.
+- UNAMBIGUOUS: we deliberately do NOT rewrite "gray NATO" (spaced), which can
+  legitimately mean a grey NATO *strap* — the object the show is named after.
+- Brand names are proper nouns, so the canonical capitalized form is always
+  correct regardless of the matched text's case.
+
+To add a term: append a (compiled_regex, replacement) tuple. Order matters where
+patterns overlap (more specific first — e.g. "blancpans" before "blancpan").
+"""
+import re
+
+# Each entry: (compiled pattern, replacement). Applied in order.
+_CORRECTIONS = [
+    # --- The Grey NATO (show name) — "nado" family only (never a URL) ---
+    (re.compile(r"\bgr[ae]y[ \-]?nado\b", re.IGNORECASE), "Grey NATO"),
+
+    # --- Hodinkee — misspelled forms only (real domain "hodinkee" untouched) ---
+    (re.compile(r"\bhodink(?:y|i|e|ey|ie|a)\b", re.IGNORECASE), "Hodinkee"),
+    (re.compile(r"\bhodingk?[iy]?\b", re.IGNORECASE), "Hodinkee"),
+
+    # --- Watch brands (curated, high-confidence STT errors) ---
+    (re.compile(r"\bblancpans\b", re.IGNORECASE), "Blancpains"),
+    (re.compile(r"\bblancpan\b", re.IGNORECASE), "Blancpain"),
+    (re.compile(r"\bblancpon\b", re.IGNORECASE), "Blancpain"),
+    (re.compile(r"\bblompa\b", re.IGNORECASE), "Blancpain"),
+    (re.compile(r"\baqua star\b", re.IGNORECASE), "Aquastar"),
+    (re.compile(r"\bpelegos\b", re.IGNORECASE), "Pelagos"),
+    (re.compile(r"\bvasheron\b", re.IGNORECASE), "Vacheron"),
+    (re.compile(r"\bodemars?\b", re.IGNORECASE), "Audemars"),
+    (re.compile(r"\btuder\b", re.IGNORECASE), "Tudor"),
+    (re.compile(r"\bspeed master\b", re.IGNORECASE), "Speedmaster"),
+    (re.compile(r"\bcerica\b", re.IGNORECASE), "Serica"),
+    (re.compile(r"\blongine\b", re.IGNORECASE), "Longines"),
+]
+
+
+def normalize_transcript_text(text: str) -> str:
+    """Apply curated transcription-vocabulary corrections to a string."""
+    if not text:
+        return text
+    for pattern, replacement in _CORRECTIONS:
+        text = pattern.sub(replacement, text)
+    return text


### PR DESCRIPTION
## Summary
Fluid Audio (STT) consistently mis-transcribes show-specific vocabulary. This adds a URL-safe correction layer applied at markdown-generation time.

- **Grey NATO**: the "nado" family (`Graynado`, `Grey Nado`, `GreyNado`, …) → **The Grey NATO** (~1,300 occurrences). Only the meaningless "nado" forms are touched — never the "nato" URL forms (`thegreynato.com`) and never `gray NATO` (which can mean the strap).
- **Hodinkee**: `Hodinky` (1,494), `Hodinki` (738), `Hodinke/Hodinkey/Hoding…` → **Hodinkee**. The real `hodinkee.com` domain is left untouched.
- **Watch brands**: `Blompa/Blancpan→Blancpain`, `Aqua star→Aquastar`, `Pelegos→Pelagos`, `Vasheron→Vacheron`, `Odemar→Audemars`, `Tuder→Tudor`, `Speed master→Speedmaster`, `Cerica→Serica`, `Longine→Longines`.

`normalize_transcript_text()` is hooked into `generate_episode_markdown` for both transcript text and synopsis, so new/reprocessed episodes are corrected automatically. Raw `whisper-output.json` STT output is left as the authentic source.

## Testing
`uv run pytest app/ -q` → 87 passed, 2 skipped (32 new tests covering corrections + URL/strap safety).

A one-time retroactive pass over existing episode transcripts + rebuild/deploy of all three sites follows separately (that content is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)