### PR TITLE
Correct spoken Grey NATO URL/email forms

### DIFF
--- a/app/test_text_corrections.py
+++ b/app/test_text_corrections.py
@@ -30,6 +30,16 @@ def test_grey_nato_leaves_urls_and_straps_untouched(text):
 
 
 @pytest.mark.parametrize("raw,expected", [
+    # spoken URL/email/handle forms — correct the "nado" domain to "greynato"
+    ("please visit thegraynado.com for details", "please visit thegreynato.com for details"),
+    ("get the feed from thegreynado.com", "get the feed from thegreynato.com"),
+    ("email thegraynadoatgmail.com", "email thegreynatoatgmail.com"),
+])
+def test_grey_nato_embedded_domain_forms(raw, expected):
+    assert normalize_transcript_text(raw) == expected
+
+
+@pytest.mark.parametrize("raw,expected", [
     ("I read it on Hodinky", "I read it on Hodinkee"),
     ("over at Hodinki radio", "over at Hodinkee radio"),
     ("the Hodinke shop", "the Hodinkee shop"),

--- a/app/text_corrections.py
+++ b/app/text_corrections.py
@@ -30,6 +30,12 @@ import re
 _CORRECTIONS = [
     # --- The Grey NATO (show name) — "nado" family only (never a URL) ---
     (re.compile(r"\bgr[ae]y[ \-]?nado\b", re.IGNORECASE), "Grey NATO"),
+    # Embedded one-word forms in spoken URLs/emails/handles, e.g.
+    # "thegraynado.com", "thegreynado.com", "TheGreyNado at gmail" — the real
+    # domain/handle is "greynato". Runs after the prose rule above so standalone
+    # occurrences have already become "Grey NATO". Still URL-safe: "nado" is the
+    # error and never appears in the real "greynato" domain.
+    (re.compile(r"gr[ae]ynado", re.IGNORECASE), "greynato"),
 
     # --- Hodinkee — misspelled forms only (real domain "hodinkee" untouched) ---
     (re.compile(r"\bhodink(?:y|i|e|ey|ie|a)\b", re.IGNORECASE), "Hodinkee"),


### PR DESCRIPTION
Follow-up to #30. The prose rule intentionally skips embedded one-word forms, leaving ~576 spoken URL/email/handle renderings (`thegraynado.com`, `TheGreyNado at gmail`, `thegraynadoatgmail.com`). Adds a URL-safe rule correcting the "nado" domain to the real `greynato` spelling.

`uv run pytest app/ -q` → 90 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)