### PR TITLE
Add 'last updated' timestamp to site home pages

### DIFF
--- a/app/flows/podcast.py
+++ b/app/flows/podcast.py
@@ -22,6 +22,7 @@ from tasks.shownotes import (
 )
 from tasks.build import (
     update_episodes_index,
+    update_home_timestamp,
     build_site,
     generate_search_index,
     deploy_site
@@ -185,6 +186,9 @@ def generate_and_deploy_site(podcast: Podcast):
         backfill_episode_shownotes(podcast.name, ep_list)
     else:
         log.warning(f"RSS feed not found for shownotes: {rss_path}")
+
+    # Step 1c: Refresh the "last updated" timestamp on the home page
+    update_home_timestamp(podcast.name)
 
     # Step 2: Build site with zensical
     site_path = build_site(podcast.name)

--- a/app/tasks/build.py
+++ b/app/tasks/build.py
@@ -1,14 +1,73 @@
 """Prefect tasks for building and deploying podcast sites."""
+import re
 import subprocess
 import sys
 import shutil
 from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 from prefect import task
 from utils.logging import get_logger
 import pagefind_bin
 
 from constants import SITE_ROOT, DEPLOY_BASE_PATH
+
+# Home-page "last updated" timestamp is shown in the site owner's timezone.
+# America/Los_Angeles auto-handles PST/PDT daylight-saving transitions.
+HOME_TIMEZONE = ZoneInfo("America/Los_Angeles")
+_LAST_UPDATED_RE = re.compile(r"^_last updated .*_$", re.MULTILINE)
+_WHAT_IS_ANCHOR = "## What is this site?"
+
+
+def apply_home_timestamp(text: str, stamp: str) -> str:
+    """Insert or update the italic timestamp line in home-page markdown.
+
+    Idempotent: replaces an existing `_last updated ..._` line if present,
+    otherwise inserts `stamp` just above the "What is this site?" section
+    (falling back to appending at the end if that anchor is missing).
+    """
+    if _LAST_UPDATED_RE.search(text):
+        return _LAST_UPDATED_RE.sub(stamp, text, count=1)
+    if _WHAT_IS_ANCHOR in text:
+        return text.replace(_WHAT_IS_ANCHOR, f"{stamp}\n\n{_WHAT_IS_ANCHOR}", 1)
+    return text.rstrip() + f"\n\n{stamp}\n"
+
+
+@task(
+    name="update-home-timestamp",
+    retries=2,
+    retry_delay_seconds=30,
+    log_prints=True
+)
+def update_home_timestamp(podcast_name: str) -> Path:
+    """Refresh the 'last updated' timestamp on the site home page.
+
+    Inserts/updates an italic timestamp line just above the
+    '## What is this site?' section of index.md, in the owner's timezone
+    (e.g. "_last updated July 17, 2026 at 9:13AM PDT_"). Idempotent — an
+    existing timestamp line is replaced rather than duplicated.
+
+    Args:
+        podcast_name: Name of the podcast
+
+    Returns:
+        Path to the home page index.md
+    """
+    log = get_logger()
+    index_md = Path(SITE_ROOT, podcast_name, 'docs', 'index.md')
+    if not index_md.exists():
+        log.warning(f"Home page not found, skipping timestamp: {index_md}")
+        return index_md
+
+    now = datetime.now(HOME_TIMEZONE)
+    stamp = f"_last updated {now.strftime('%B %-d, %Y at %-I:%M%p %Z')}_"
+
+    text = index_md.read_text()
+    if _WHAT_IS_ANCHOR not in text and not _LAST_UPDATED_RE.search(text):
+        log.warning(f"No '{_WHAT_IS_ANCHOR}' anchor in {index_md}; appending timestamp")
+    index_md.write_text(apply_home_timestamp(text, stamp))
+    log.info(f"Updated home timestamp for {podcast_name}: {stamp}")
+    return index_md
 
 
 @task(

--- a/app/test_home_timestamp.py
+++ b/app/test_home_timestamp.py
@@ -1,0 +1,50 @@
+"""Tests for the home-page 'last updated' timestamp insertion."""
+from tasks.build import apply_home_timestamp
+
+STAMP = "_last updated July 17, 2026 at 9:13AM PDT_"
+STAMP2 = "_last updated July 18, 2026 at 4:05PM PDT_"
+
+PAGE = """## Welcome!
+
+## What is TGN?
+
+Some intro text.
+
+## What is this site?
+_This_ site is a side project.
+
+## Contact me
+"""
+
+
+def test_inserts_above_what_is_this_site():
+    out = apply_home_timestamp(PAGE, STAMP)
+    assert STAMP in out
+    # timestamp appears immediately before the anchor
+    assert f"{STAMP}\n\n## What is this site?" in out
+    # inserted before, not after, the anchor
+    assert out.index(STAMP) < out.index("## What is this site?")
+    # original content preserved
+    assert "## What is TGN?" in out and "## Contact me" in out
+
+
+def test_idempotent_replaces_existing():
+    once = apply_home_timestamp(PAGE, STAMP)
+    twice = apply_home_timestamp(once, STAMP2)
+    assert twice.count("_last updated ") == 1  # no duplication
+    assert STAMP2 in twice and STAMP not in twice
+
+
+def test_fallback_appends_when_anchor_missing():
+    text = "## Welcome!\n\nNo standard sections here.\n"
+    out = apply_home_timestamp(text, STAMP)
+    assert STAMP in out
+    assert out.count("_last updated ") == 1
+
+
+def test_only_one_anchor_replaced_ever():
+    # running the full build many times must never accumulate timestamps
+    text = PAGE
+    for stamp in (STAMP, STAMP2, STAMP, STAMP2):
+        text = apply_home_timestamp(text, stamp)
+    assert text.count("_last updated ") == 1


### PR DESCRIPTION
## Summary
Adds a human-readable last-updated timestamp just above the "What is this site?" section on each site's home page, in the owner's timezone.

Example: `_last updated July 17, 2026 at 9:13AM PDT_`

- New `update_home_timestamp` task (in build.py) + pure, testable `apply_home_timestamp` helper.
- **Idempotent**: replaces an existing timestamp line instead of duplicating, so repeated builds never accumulate.
- Timezone `America/Los_Angeles` — auto-handles PST/PDT daylight saving (shows PDT in summer, PST in winter).
- Wired into `generate_and_deploy_site` right before the build step, so it refreshes on every deploy.

## Testing
`uv run pytest app/ -q` → 94 passed, 2 skipped (4 new tests: insertion position, idempotency, anchor fallback).

Applies to all three sites; a rebuild/deploy follows to make it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)